### PR TITLE
control_look_ahead_poses can now be dynamically reconfigured

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -62,6 +62,10 @@ grp_trajectory.add("publish_feedback",   bool_t,   0,
   "Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)",
   False)    
 
+grp_trajectory.add("control_look_ahead_poses", int_t, 0,
+  "Index of the pose used to extract the velocity command",
+  1, 1, 100)     
+
 grp_trajectory.add("visualize_with_time_as_z_axis_scale",    double_t,   0,
   "If this value is bigger than 0, the trajectory and obstacles are visualized in 3d using the time as the z-axis scaled by this value. Most useful for dynamic obstacles.",
   0, 0, 1)

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -197,6 +197,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   trajectory.force_reinit_new_goal_angular = cfg.force_reinit_new_goal_angular;
   trajectory.feasibility_check_no_poses = cfg.feasibility_check_no_poses;
   trajectory.publish_feedback = cfg.publish_feedback;
+  trajectory.control_look_ahead_poses = cfg.control_look_ahead_poses;
   
   // Robot     
   robot.max_vel_x = cfg.max_vel_x;


### PR DESCRIPTION
We have noticed that this parameter is very useful for robots a bit lethargic reacting to commands. Setting to a higher than 1 value reduces progressively oscillations around the global path. However, 1 is the perfect value for precise control of the same lethargic robots when moving slow.