### PR TITLE
Improved visualization of robot footprint line model

### DIFF
--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -477,8 +477,6 @@ public:
   {   
     markers.push_back(visualization_msgs::Marker());
     visualization_msgs::Marker& marker = markers.back();
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    current_pose.toPoseMsg(marker.pose); // all points are transformed into the robot frame!
     
     // line
     geometry_msgs::Point line_start_world;
@@ -493,8 +491,45 @@ public:
     line_end_world.z = 0;
     marker.points.push_back(line_end_world);
 
-    marker.scale.x = 0.05; 
-    marker.color = color;
+    // footprint with min_obstacle_dist
+    markers.push_back(visualization_msgs::Marker());
+    visualization_msgs::Marker& marker2 = markers.back();
+
+    const double r = 0.3;
+    const double ori = atan2(line_end_.y() - line_start_.y(), line_end_.x() - line_start_.x());
+
+    // first half-circle
+    for (double theta = M_PI_2+ori; theta <= 3*M_PI_2+ori; theta += M_PI / 8)
+    {
+      geometry_msgs::Point pt;
+      pt.x = line_start_.x() + r * cos(theta);
+      pt.y = line_start_.y() + r * sin(theta);
+      marker2.points.push_back(pt);
+    }
+
+    // second half-circle
+    for (double theta = -M_PI_2+ori; theta <= M_PI_2+ori; theta += M_PI / 8)
+    {
+      geometry_msgs::Point pt;
+      pt.x = line_end_.x() + r * cos(theta);
+      pt.y = line_end_.y() + r * sin(theta);
+      marker2.points.push_back(pt);
+    }
+
+    // duplicate 1st point to close shape
+    geometry_msgs::Point pt;
+    pt.x = line_start_.x() + r * cos(M_PI_2+ori);
+    pt.y = line_start_.y() + r * sin(M_PI_2+ori);
+    marker2.points.push_back(pt);
+
+    // common meta stuff
+    for (auto& marker : markers)
+    {
+      marker.type = visualization_msgs::Marker::LINE_STRIP;
+      current_pose.toPoseMsg(marker.pose); // all points are transformed into the robot frame!
+      marker.scale.x = 0.05; 
+      marker.color = color;
+    }
   }
   
   /**

--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -493,7 +493,7 @@ public:
     line_end_world.z = 0;
     marker.points.push_back(line_end_world);
 
-    marker.scale.x = 0.05; 
+    marker.scale.x = 0.025; 
     marker.color = color;    
 
     // footprint with min_obstacle_dist
@@ -504,7 +504,7 @@ public:
     marker2.color = color;
     current_pose.toPoseMsg(marker2.pose); // all points are transformed into the robot frame!
 
-    const double n = 8;
+    const double n = 9;
     const double r = min_obstacle_dist_;
     const double ori = atan2(line_end_.y() - line_start_.y(), line_end_.x() - line_start_.x());
 

--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -477,6 +477,8 @@ public:
   {   
     markers.push_back(visualization_msgs::Marker());
     visualization_msgs::Marker& marker = markers.back();
+    marker.type = visualization_msgs::Marker::LINE_STRIP;
+    current_pose.toPoseMsg(marker.pose); // all points are transformed into the robot frame!
     
     // line
     geometry_msgs::Point line_start_world;
@@ -491,9 +493,16 @@ public:
     line_end_world.z = 0;
     marker.points.push_back(line_end_world);
 
+    marker.scale.x = 0.05; 
+    marker.color = color;    
+
     // footprint with min_obstacle_dist
     markers.push_back(visualization_msgs::Marker());
     visualization_msgs::Marker& marker2 = markers.back();
+    marker2.type = visualization_msgs::Marker::LINE_STRIP;
+    marker2.scale.x = 0.025; 
+    marker2.color = color;
+    current_pose.toPoseMsg(marker2.pose); // all points are transformed into the robot frame!
 
     const double n = 8;
     const double r = min_obstacle_dist_;
@@ -522,15 +531,6 @@ public:
     pt.x = line_start_.x() + r * cos(M_PI_2 + ori);
     pt.y = line_start_.y() + r * sin(M_PI_2 + ori);
     marker2.points.push_back(pt);
-
-    // common meta stuff
-    for (auto& marker : markers)
-    {
-      marker.type = visualization_msgs::Marker::LINE_STRIP;
-      current_pose.toPoseMsg(marker.pose); // all points are transformed into the robot frame!
-      marker.scale.x = 0.05; 
-      marker.color = color;
-    }
   }
   
   /**

--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -403,7 +403,7 @@ public:
   * @param line_start start coordinates (only x and y) of the line (w.r.t. robot center at (0,0))
   * @param line_end end coordinates (only x and y) of the line (w.r.t. robot center at (0,0))
   */
-  LineRobotFootprint(const Eigen::Vector2d& line_start, const Eigen::Vector2d& line_end)
+  LineRobotFootprint(const Eigen::Vector2d& line_start, const Eigen::Vector2d& line_end, const double min_obstacle_dist) : min_obstacle_dist_(min_obstacle_dist)
   {
     setLine(line_start, line_end);
   }
@@ -495,11 +495,12 @@ public:
     markers.push_back(visualization_msgs::Marker());
     visualization_msgs::Marker& marker2 = markers.back();
 
-    const double r = 0.3;
+    const double n = 8;
+    const double r = min_obstacle_dist_;
     const double ori = atan2(line_end_.y() - line_start_.y(), line_end_.x() - line_start_.x());
 
     // first half-circle
-    for (double theta = M_PI_2+ori; theta <= 3*M_PI_2+ori; theta += M_PI / 8)
+    for (double theta = M_PI_2 + ori; theta <= 3 * M_PI_2 + ori; theta += M_PI / n)
     {
       geometry_msgs::Point pt;
       pt.x = line_start_.x() + r * cos(theta);
@@ -508,7 +509,7 @@ public:
     }
 
     // second half-circle
-    for (double theta = -M_PI_2+ori; theta <= M_PI_2+ori; theta += M_PI / 8)
+    for (double theta = -M_PI_2 + ori; theta <= M_PI_2 + ori; theta += M_PI / n)
     {
       geometry_msgs::Point pt;
       pt.x = line_end_.x() + r * cos(theta);
@@ -518,8 +519,8 @@ public:
 
     // duplicate 1st point to close shape
     geometry_msgs::Point pt;
-    pt.x = line_start_.x() + r * cos(M_PI_2+ori);
-    pt.y = line_start_.y() + r * sin(M_PI_2+ori);
+    pt.x = line_start_.x() + r * cos(M_PI_2 + ori);
+    pt.y = line_start_.y() + r * sin(M_PI_2 + ori);
     marker2.points.push_back(pt);
 
     // common meta stuff
@@ -561,6 +562,7 @@ private:
 
   Eigen::Vector2d line_start_;
   Eigen::Vector2d line_end_;
+  const double min_obstacle_dist_ = 0.0;
   
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -193,9 +193,10 @@ public:
   /**
    * @brief Get the current robot footprint/contour model
    * @param nh const reference to the local ros::NodeHandle
+   * @param config const reference to the current configuration
    * @return Robot footprint model used for optimization
    */
-  static RobotFootprintModelPtr getRobotFootprintFromParamServer(const ros::NodeHandle& nh);
+  static RobotFootprintModelPtr getRobotFootprintFromParamServer(const ros::NodeHandle& nh, const TebConfig& config);
   
   /** 
    * @brief Set the footprint from the given XmlRpcValue.

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -388,9 +388,10 @@ protected:
   
   void configureBackupModes(std::vector<geometry_msgs::PoseStamped>& transformed_plan,  int& goal_idx);
 
-
   
 private:
+  void robotModelPubTimerCB(const ros::TimerEvent& event);
+
   // Definition of member variables
 
   // external objects (store weak pointers)
@@ -399,6 +400,9 @@ private:
   tf2_ros::Buffer* tf_; //!< pointer to tf buffer
     
   // internal objects (memory management owned)
+  ros::Publisher robot_model_pub_; //!< Publisher for the robot footprint model
+  ros::Timer robot_model_pub_timer_; //!< Timer for publishing the robot footprint model
+  RobotFootprintModelPtr robot_model_; //!< The robot footprint model currently in use
   PlannerInterfacePtr planner_; //!< Instance of the underlying optimal planner class
   ObstContainer obstacles_; //!< Obstacle vector that should be considered during local trajectory optimization
   ViaPointContainer via_points_; //!< Container of via-points that should be considered during local trajectory optimization
@@ -443,6 +447,8 @@ private:
     
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
+
+  static constexpr double ROBOT_MODEL_PUB_RATE = 10; //!< Rate (hertz) for publishing the robot model
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -83,8 +83,8 @@ void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config,
   cfg_.reconfigure(config);
   ros::NodeHandle nh("~/" + name_);
   // create robot footprint/contour model for optimization
-  RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
-  planner_->updateRobotModel(robot_model);
+  robot_model_ = getRobotFootprintFromParamServer(nh);
+  planner_->updateRobotModel(robot_model_);
 }
 
 void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costmap_2d::Costmap2DROS* costmap_ros)
@@ -106,17 +106,17 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     visualization_ = TebVisualizationPtr(new TebVisualization(nh, cfg_)); 
         
     // create robot footprint/contour model for optimization
-    RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
+    robot_model_ = getRobotFootprintFromParamServer(nh);
     
     // create the planner instance
     if (cfg_.hcp.enable_homotopy_class_planning)
     {
-      planner_ = PlannerInterfacePtr(new HomotopyClassPlanner(cfg_, &obstacles_, robot_model, visualization_, &via_points_));
+      planner_ = PlannerInterfacePtr(new HomotopyClassPlanner(cfg_, &obstacles_, robot_model_, visualization_, &via_points_));
       ROS_INFO("Parallel planning in distinctive topologies enabled.");
     }
     else
     {
-      planner_ = PlannerInterfacePtr(new TebOptimalPlanner(cfg_, &obstacles_, robot_model, visualization_, &via_points_));
+      planner_ = PlannerInterfacePtr(new TebOptimalPlanner(cfg_, &obstacles_, robot_model_, visualization_, &via_points_));
       ROS_INFO("Parallel planning in distinctive topologies disabled.");
     }
     
@@ -170,7 +170,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     dynamic_recfg_->setCallback(cb);
     
     // validate optimization footprint and costmap footprint
-    validateFootprints(robot_model->getInscribedRadius(), robot_inscribed_radius_, cfg_.obstacles.min_obstacle_dist);
+    validateFootprints(robot_model_->getInscribedRadius(), robot_inscribed_radius_, cfg_.obstacles.min_obstacle_dist);
         
     // setup callback for custom obstacles
     custom_obst_sub_ = nh.subscribe("obstacles", 1, &TebLocalPlannerROS::customObstacleCB, this);
@@ -183,6 +183,10 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     double controller_frequency = 5;
     nh_move_base.param("controller_frequency", controller_frequency, controller_frequency);
     failure_detector_.setBufferLength(std::round(cfg_.recovery.oscillation_filter_duration*controller_frequency));
+
+    // init robot model pub
+    robot_model_pub_ = nh.advertise<visualization_msgs::Marker>("robot_model", 1000);
+    robot_model_pub_timer_ = nh.createTimer(ros::Duration(1.0 / ROBOT_MODEL_PUB_RATE), &TebLocalPlannerROS::robotModelPubTimerCB, this);
     
     // set initialized flag
     initialized_ = true;
@@ -1203,6 +1207,37 @@ double TebLocalPlannerROS::getNumberFromXMLRPC(XmlRpc::XmlRpcValue& value, const
      throw std::runtime_error("Values in the footprint specification must be numbers");
    }
    return value.getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(value) : (double)(value);
+}
+
+void TebLocalPlannerROS::robotModelPubTimerCB(const ros::TimerEvent& event)
+{
+  geometry_msgs::PoseStamped robot_pose;
+  costmap_ros_->getRobotPose(robot_pose);
+
+  // create markers with green color
+  std::vector<visualization_msgs::Marker> markers;
+  std_msgs::ColorRGBA green = TebVisualization::toColorMsg(0.5, 0.0, 0.8, 0.0);
+  robot_model_->visualizeRobot(PoseSE2(robot_pose.pose), markers, green);
+
+  // no need to do anything if no markers
+  if (markers.empty())
+    return;
+  
+  // publish the markers
+  int idx = 1;
+  for (std::vector<visualization_msgs::Marker>::iterator marker_it = markers.begin(); marker_it != markers.end(); ++marker_it, ++idx)
+  {
+    marker_it->header.frame_id = cfg_.map_frame;
+    marker_it->header.stamp = event.current_real;
+    marker_it->action = visualization_msgs::Marker::ADD;
+    marker_it->ns = "robot_footprint_model";
+    marker_it->id = idx;
+
+    // automatic cleanup!
+    marker_it->lifetime = ros::Duration(0.5);
+
+    robot_model_pub_.publish(*marker_it);
+  }
 }
 
 } // end namespace teb_local_planner

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -83,7 +83,7 @@ void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config,
   cfg_.reconfigure(config);
   ros::NodeHandle nh("~/" + name_);
   // create robot footprint/contour model for optimization
-  robot_model_ = getRobotFootprintFromParamServer(nh);
+  robot_model_ = getRobotFootprintFromParamServer(nh, cfg_);
   planner_->updateRobotModel(robot_model_);
 }
 
@@ -106,7 +106,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     visualization_ = TebVisualizationPtr(new TebVisualization(nh, cfg_)); 
         
     // create robot footprint/contour model for optimization
-    robot_model_ = getRobotFootprintFromParamServer(nh);
+    robot_model_ = getRobotFootprintFromParamServer(nh, cfg_);
     
     // create the planner instance
     if (cfg_.hcp.enable_homotopy_class_planning)
@@ -1036,7 +1036,7 @@ void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::Path::ConstPtr& via_p
   custom_via_points_active_ = !via_points_.empty();
 }
      
-RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(const ros::NodeHandle& nh)
+RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(const ros::NodeHandle& nh, const TebConfig& config)
 {
   std::string model_name; 
   if (!nh.getParam("footprint_model/type", model_name))
@@ -1090,7 +1090,7 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer(cons
     
     ROS_INFO_STREAM("Footprint model 'line' (line_start: [" << line_start[0] << "," << line_start[1] <<"]m, line_end: ["
                      << line_end[0] << "," << line_end[1] << "]m) loaded for trajectory optimization.");
-    return boost::make_shared<LineRobotFootprint>(Eigen::Map<const Eigen::Vector2d>(line_start.data()), Eigen::Map<const Eigen::Vector2d>(line_end.data()));
+    return boost::make_shared<LineRobotFootprint>(Eigen::Map<const Eigen::Vector2d>(line_start.data()), Eigen::Map<const Eigen::Vector2d>(line_end.data()), config.obstacles.min_obstacle_dist);
   }
   
   // two circles

--- a/src/test_optim_node.cpp
+++ b/src/test_optim_node.cpp
@@ -147,7 +147,7 @@ int main( int argc, char** argv )
   visual = TebVisualizationPtr(new TebVisualization(n, config));
   
   // Setup robot shape model
-  RobotFootprintModelPtr robot_model = TebLocalPlannerROS::getRobotFootprintFromParamServer(n);
+  RobotFootprintModelPtr robot_model = TebLocalPlannerROS::getRobotFootprintFromParamServer(n, config);
   
   // Setup planner (homotopy class planning or just the local teb planner)
   if (config.hcp.enable_homotopy_class_planning)


### PR DESCRIPTION
## Description

Improved visualization of the robot footprint line model to better reflect what the footprint actually looks like:

![](http://wiki.ros.org/teb_local_planner/Tutorials/Obstacle%20Avoidance%20and%20Robot%20Footprint%20Model?action=AttachFile&do=get&target=line_model.png)

---

As a bonus, also added a publisher that prints the robot footprint at 10 Hz to the topic `~<name>/robot_model`.
The footprint was only published while TEB was active, which was a pain when debugging.

_(we likely don't want to include this bonus if we make a PR upstream)_